### PR TITLE
Jyxo\Beholder - Memcached TestCase produces Notice when connecting failures

### DIFF
--- a/Jyxo/Beholder/TestCase/Memcached.php
+++ b/Jyxo/Beholder/TestCase/Memcached.php
@@ -72,9 +72,9 @@ class Memcached extends \Jyxo\Beholder\TestCase
 		// Status label
 		$description = gethostbyaddr($this->ip) . ':' . $this->port;
 
-		// Connection
+		// Connection (@ due to notice)
 		$memcache = new \Memcache();
-		if (false === $memcache->connect($this->ip, $this->port)) {
+		if (false === @$memcache->connect($this->ip, $this->port)) {
 			return new \Jyxo\Beholder\Result(\Jyxo\Beholder\Result::FAILURE, sprintf('Connection error %s', $description));
 		}
 


### PR DESCRIPTION
Memcache class produces Notice when connect method is called and connection failures (eg. memcached daemon is stopped). I suggest using "@" to waste the notice althought TestCase still correctly failures.

Tested on PHP 5.3.8 at Windows XP/Debian 6.0, PHP from dotdeb.org repository
