### PR TITLE
Fix "Compilation failed: invalid range in character class"

### DIFF
--- a/Jyxo/Input/Validator/IsUrl.php
+++ b/Jyxo/Input/Validator/IsUrl.php
@@ -44,7 +44,7 @@ class IsUrl extends \Jyxo\Input\Validator\AbstractValidator
 		// :port/path/file.extension
 		$patternUrl .= '(?::[0-9]+)?(?:(?:/+[-\w\pL\pN\~.,:!%]+)*(?:/|[.][a-z0-9]{2,4})?)?';
 		// ?query#hash
-		$patternUrl .= '(?:[?&][\]\[-\w\pL\pN.,?!\~%#@&;:/\'\=+]*)?(?:#[\]\[-\w\pL\pN.,?!\~%@&;:/\'\=+]*)?';
+		$patternUrl .= '(?:[?&][\]\[\-\w\pL\pN.,?!\~%#@&;:/\'\=+]*)?(?:#[\]\[\-\w\pL\pN.,?!\~%@&;:/\'\=+]*)?';
 
 		if (!preg_match('~^' . $patternUrl . '$~i', (string) $value)) {
 			return false;


### PR DESCRIPTION
Some PCRE versions don't like the minus character unescaped in character classes, I believe this will fix the issue.
