### PR TITLE
Webdav client pluggable logger

### DIFF
--- a/Jyxo/Webdav/Client.php
+++ b/Jyxo/Webdav/Client.php
@@ -97,11 +97,11 @@ class Client
 	protected $curlSslOptions = array();
 
 	/**
-	 * File for log.
+	 * Logger.
 	 *
-	 * @var string
+	 * @var LoggerInterface
 	 */
-	protected $logFile = null;
+	protected $logger = null;
 
 	/**
 	 * If parallel request sending is enabled.
@@ -156,18 +156,14 @@ class Client
 	}
 
 	/**
-	 * Sets a log file.
+	 * Sets a logger.
 	 *
-	 * @param string $file
+	 * @param LoggerInterface $logger Logger
 	 * @return \Jyxo\Webdav\Client
 	 */
-	public function setLogFile($file)
+	public function setLogger(LoggerInterface $logger)
 	{
-		if ((is_file($file) && !is_writable($file)) || !is_writable(dirname($file))) {
-			throw new \InvalidArgumentException('The log file is not writeable');
-		}
-
-		$this->logFile = (string) $file;
+		$this->logger = $logger;
 
 		return $this;
 	}
@@ -568,9 +564,8 @@ class Client
 					$responses[$server] = $response;
 
 					// Log
-					if ($this->logFile !== null) {
-						$data = sprintf("[%s]: %s %d %s\n", date('Y-m-d H:i:s'), $request->getRequestMethod(), $response->getResponseCode(), $request->getRequestUrl());
-						file_put_contents($this->logFile, $data, FILE_APPEND);
+					if ($this->logger !== null) {
+						$this->logger->log(sprintf("%s %d %s", $request->getRequestMethod(), $response->getResponseCode(), $request->getRequestUrl()));
 					}
 				}
 
@@ -587,9 +582,8 @@ class Client
 					$responses[$server] = $response;
 
 					// Log
-					if ($this->logFile !== null) {
-						$data = sprintf("[%s]: %s %d %s\n", date('Y-m-d H:i:s'), $request->getRequestMethod(), $response->getResponseCode(), $request->getRequestUrl());
-						file_put_contents($this->logFile, $data, FILE_APPEND);
+					if ($this->logger !== null) {
+						$this->logger->log(sprintf("%s %d %s", $request->getRequestMethod(), $response->getResponseCode(), $request->getRequestUrl()));
 					}
 				}
 			}

--- a/Jyxo/Webdav/Client.php
+++ b/Jyxo/Webdav/Client.php
@@ -613,7 +613,13 @@ class Client
 			$client->enqueue($request);
 			$client->send();
 
-			return $client->getResponse();
+			$response = $client->getResponse();
+
+			if (null !== $this->logger) {
+				$this->logger->log(sprintf("%s %d %s", $request->getRequestMethod(), $response->getResponseCode(), $request->getRequestUrl()));
+			}
+
+			return $response;
 		} catch (\http\Exception $e) {
 			throw new Exception($e->getMessage(), 0, $e);
 		}

--- a/Jyxo/Webdav/FileLogger.php
+++ b/Jyxo/Webdav/FileLogger.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Jyxo PHP Library
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://github.com/jyxo/php/blob/master/license.txt
+ */
+
+namespace Jyxo\Webdav;
+
+/**
+ * File based WebDav logger.
+ *
+ * @category Jyxo
+ * @package Jyxo\Webdav
+ * @copyright Copyright (c) 2005-2011 Jyxo, s.r.o.
+ * @license https://github.com/jyxo/php/blob/master/license.txt
+ * @author Ondřej Nešpor
+ */
+class FileLogger implements LoggerInterface
+{
+
+	/**
+	 * Logging filename.
+	 *
+	 * @var string
+	 */
+	private $fileName;
+
+	/**
+	 * Creates the logger.
+	 *
+	 * @param $fileName Logging filename
+	 */
+	public function __construct($fileName)
+	{
+		$this->fileName = $fileName;
+	}
+
+	/**
+	 * Logs the given message.
+	 *
+	 * @param $message Message to be logged
+	 */
+	public function log($message)
+	{
+		file_put_contents($this->fileName, sprintf("[%s]: %s\n", date('Y-m-d H:i:s'), $message), FILE_APPEND);
+	}
+
+}

--- a/Jyxo/Webdav/LoggerInterface.php
+++ b/Jyxo/Webdav/LoggerInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Jyxo PHP Library
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://github.com/jyxo/php/blob/master/license.txt
+ */
+
+namespace Jyxo\Webdav;
+
+/**
+ * Interface for WebDav loggers.
+ *
+ * @category Jyxo
+ * @package Jyxo\Webdav
+ * @copyright Copyright (c) 2005-2011 Jyxo, s.r.o.
+ * @license https://github.com/jyxo/php/blob/master/license.txt
+ * @author Ondřej Nešpor
+ */
+interface LoggerInterface
+{
+
+	/**
+	 * Logs the given message.
+	 *
+	 * @param $message Message to be logged
+	 */
+	public function log($message);
+
+}

--- a/Jyxo/Webdav/MonologLogger.php
+++ b/Jyxo/Webdav/MonologLogger.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Jyxo PHP Library
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://github.com/jyxo/php/blob/master/license.txt
+ */
+
+namespace Jyxo\Webdav;
+
+/**
+ * Bridge to a Monolog logger.
+ *
+ * @category Jyxo
+ * @package Jyxo\Webdav
+ * @copyright Copyright (c) 2005-2011 Jyxo, s.r.o.
+ * @license https://github.com/jyxo/php/blob/master/license.txt
+ * @author Ondřej Nešpor
+ */
+class MonologLogger implements LoggerInterface
+{
+
+	/**
+	 * Monolog logger.
+	 *
+	 * @var \Monolog\Logger
+	 */
+	private $logger;
+
+	/**
+	 * Message level
+	 *
+	 * @var int
+	 */
+	private $level;
+
+	/**
+	 * Creates the logger.
+	 *
+	 * @param \Monolog\Logger $logger Monolog logger
+	 * @param int $level Message level
+	 */
+	public function __construct(\Monolog\Logger $logger, $level)
+	{
+		$this->logger = $logger;
+		$this->level = $level;
+	}
+
+	/**
+	 * Logs the given message.
+	 *
+	 * @param $message Message to be logged
+	 */
+	public function log($message)
+	{
+		$this->logger->addRecord($this->level, $message);
+	}
+
+}


### PR DESCRIPTION
This patch allows you to inject a logger instance (instance of LoggerInterface) so that the WebDAV client does not necessary have to log only to a file.

Two loggers are part of the patch:
1. File logger that brings the old functionality.
2. Monolog wrapper.

The last thing is that this patch also add logging to the ```sendRequest()``` method.