### PR TITLE
Setting request headers fix

### DIFF
--- a/Jyxo/Webdav/Client.php
+++ b/Jyxo/Webdav/Client.php
@@ -656,8 +656,7 @@ class Client
 		$request = new \http\Client\Request($method, $server . $path);
 		$request->setOptions($this->curlOptions);
 		$request->setSslOptions($this->curlSslOptions);
-		$request->setHeader('Expect', '');
-		$request->setHeaders($headers);
+		$request->setHeaders($headers + array('Expect' => ''));
 		return $request;
 	}
 


### PR DESCRIPTION
We are using version 2.3.2 of the HTTP extension (cURL 7.29.0) and it seems that developers have decided that ```http\Client\Request::setHeaders()``` should overwrite anything that has been set before. That's why the ```Expect``` header is not sent and the the ```100: Continue``` status is returned that results in an error.