### PR TITLE
Reading text/content from empty XML tags

### DIFF
--- a/Jyxo/XmlReader.php
+++ b/Jyxo/XmlReader.php
@@ -54,6 +54,10 @@ class XmlReader extends \XMLReader
 	 */
 	public function getTextValue()
 	{
+		if (self::ELEMENT === $this->nodeType && $this->isEmptyElement) {
+			return '';
+		}
+
 		$depth = 1;
 		$text = '';
 
@@ -78,6 +82,10 @@ class XmlReader extends \XMLReader
 	 */
 	public function getContent()
 	{
+		if (self::ELEMENT === $this->nodeType && $this->isEmptyElement) {
+			return '';
+		}
+
 		$depth = 1;
 		$text = '';
 

--- a/tests/Jyxo/XmlReaderTest.php
+++ b/tests/Jyxo/XmlReaderTest.php
@@ -65,6 +65,7 @@ class XmlReaderTest extends \PHPUnit_Framework_TestCase
 	{
 		// In the form: tag (key), expected value (value)
 		$tests = array();
+		$tests['zero'] = '';
 		$tests['one'] = 'word';
 		$tests['second'] = 'two words';
 		$tests['third'] = 'three simple words';
@@ -93,6 +94,7 @@ class XmlReaderTest extends \PHPUnit_Framework_TestCase
 	{
 		// In the form: tag (key), expected value (value)
 		$tests = array();
+		$tests['zero'] = '';
 		$tests['one'] = 'word';
 		$tests['second'] = 'two <tag>words</tag>';
 		$tests['third'] = 'three<empty/><tag>simple</tag> words';

--- a/tests/files/xmlreader/content.xml
+++ b/tests/files/xmlreader/content.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <test>
+	<zero/>
 	<one>word</one>
 	<second>two <tag>words</tag></second>
 	<third>three<empty/><tag>simple</tag> words</third>

--- a/tests/files/xmlreader/text.xml
+++ b/tests/files/xmlreader/text.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <test>
+	<zero/>
 	<one>word</one>
 	<second>two words</second>
 	<third>three simple words</third>


### PR DESCRIPTION
Right now, if an ```XmlReader``` is positioned on an empty tag and you call ```getTextValue()``` or ```getContent()```, it calls ```read()``` as the first thing, advances beyond the empty tag and effectively starts processing its parent returning the text/XML content from that point to its end.

The obvious answer could be "you silly, don't run it on an empty tag" but I'd like to propose a consistent solution.

Hence this PR :)