### PR TITLE
Parallel requests logging fix

### DIFF
--- a/Jyxo/Webdav/Client.php
+++ b/Jyxo/Webdav/Client.php
@@ -545,7 +545,7 @@ class Client
 				// Log
 				if (null !== $this->logger) {
 					foreach ($responses as $server => $response) {
-						$this->logger->log(sprintf("%s %d %s", $request->getMethod(), $response->getStatusCode(), $request->getUri()));
+						$this->logger->log(sprintf("%s %d %s", $requests[$server]->getMethod(), $response->getStatusCode(), $requests[$server]->getUri()));
 					}
 				}
 


### PR DESCRIPTION
The ```$request``` variable contains the latest request processed causing wrong URIs being logged (every requests is logged with the URI of the latest request).