### PR TITLE
Fix "composer install" on Mac OS X

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"ext-imap": "To use Jyxo\\Mail\\Parser"
 	},
 	"autoload": {
-		"psr-0": { "Jyxo": "/" }
+		"psr-4": { "Jyxo\\": ["Jyxo/"] }
 	},
 	"config": {
 		"bin-dir": "bin",


### PR DESCRIPTION
Previous version caused "RecursiveDirectoryIterator::__construct(//.DocumentRevisions-V100): failed to open dir: Permission denied"